### PR TITLE
提供直接计算token的API

### DIFF
--- a/aioqiniu/__init__.py
+++ b/aioqiniu/__init__.py
@@ -40,6 +40,22 @@ class QiniuClient(object):
             self._auto_close_client = True
         self._client = client
 
+    def token(self, data):
+        """
+        
+        :param data: 待签名的数据
+        :return: 数据签名
+        """
+        return self._auth.token(data)
+
+    def token_with_data(self, data):
+        """
+        
+        :param data: 待签名的数据
+        :return: 数据签名，含已编码的原数据
+        """
+        return self._auth.token_with_data(data)
+
     def get_access_token(self, path: str, query="", body="") -> str:
         """生成七牛云的管理凭证
 


### PR DESCRIPTION
七牛的部分图片处理接口所需要的签名，需要直接根据字符串来计算，其算法略有别于管理凭证的生成。

当前需要通过`client._auth`来生成，需要访问`_`开头的成员。因此增加API来代理。